### PR TITLE
fix: import `path`

### DIFF
--- a/mix.js
+++ b/mix.js
@@ -1,4 +1,5 @@
 const mix = require('laravel-mix');
+const path = require('path');
 
 class LangExtension {
 	register(lang) {


### PR DESCRIPTION
Fixes

```
[webpack-cli] ReferenceError: path is not defined
    at LangExtension.webpackConfig (/Users/danmichael/projects/uio/ub-baser/node_modules/laravel-vue-lang/mix.js:18:44)
```

which I started getting after upgrading to [laravel-mix 6](https://github.com/JeffreyWay/laravel-mix/releases/tag/v6.0.0). Seems like laravel-mix 6 is a quite major upgrade which adds Webpack 5 support, but I wasn't able to pinpoint exactly why this worked without the import in laravel-mix 5 :/

Note: I wasn't able to fully test this, since I had another dependency that was not yet ready for Webpack 5 and had to roll back to laravel-mix 5 for now.
