### PR TITLE
fix: remove Laravel Mix 6 warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
 		"vue": "^2.6.10"
 	},
 	"peerDependencies": {
-		"laravel-mix": "^4.0.0 || ^5.0.0"
+		"laravel-mix": "^4.0.0 || ^5.0.0 || ^6.0.0"
 	}
 }


### PR DESCRIPTION
Fix npm warn: "requires a peer of laravel-mix@^4.0.0 || ^5.0.0 but none is installed"